### PR TITLE
RFC-2141 NID compliance

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,8 +3,8 @@ skip_tags: true
 clone_depth: 10
 environment:
   matrix:
-    - JAVA_HOME: C:\Program Files\Java\jdk1.7.0
-    #- JAVA_HOME: C:\Program Files\Java\jdk1.8.0
+    #- JAVA_HOME: C:\Program Files\Java\jdk1.7.0
+    - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
 branches:
   only:
     - master

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,6 +21,7 @@ install:
   - cmd: SET PATH=C:\maven\apache-maven-3.2.5\bin;%JAVA_HOME%\bin;%PATH:C:\Ruby193\bin;=%
   - cmd: SET MAVEN_OPTS=-XX:MaxPermSize=2g -Xmx4g
   - cmd: SET JAVA_OPTS=-XX:MaxPermSize=2g -Xmx4g
+  - cmd: SET M2_HOME=C:\maven\apache-maven-3.2.5
   - cmd: mvn --version
   - cmd: java -version
 build_script:

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <parent>
         <groupId>com.jcabi</groupId>
         <artifactId>jcabi</artifactId>
-        <version>1.17</version>
+        <version>2.0-SNAPSHOT</version>
     </parent>
     <artifactId>jcabi-urn</artifactId>
     <version>1.0-SNAPSHOT</version>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <parent>
         <groupId>com.jcabi</groupId>
         <artifactId>jcabi</artifactId>
-        <version>2.0-SNAPSHOT</version>
+        <version>1.25.2</version>
     </parent>
     <artifactId>jcabi-urn</artifactId>
     <version>1.0-SNAPSHOT</version>
@@ -69,6 +69,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
+            <version>1.18.16</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
         <groupId>com.jcabi</groupId>
         <artifactId>jcabi</artifactId>
         <version>1.25.2</version>
+        <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <artifactId>jcabi-urn</artifactId>
     <version>1.0-SNAPSHOT</version>

--- a/src/main/java/com/jcabi/urn/URN.java
+++ b/src/main/java/com/jcabi/urn/URN.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2012-2017, jcabi.com
  * All rights reserved.
  *
@@ -31,9 +31,6 @@ package com.jcabi.urn;
 
 import com.jcabi.aspects.Immutable;
 import com.jcabi.aspects.Tv;
-import lombok.EqualsAndHashCode;
-import org.apache.commons.lang3.StringUtils;
-
 import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
@@ -41,6 +38,8 @@ import java.net.URISyntaxException;
 import java.net.URLDecoder;
 import java.util.Map;
 import java.util.TreeMap;
+import lombok.EqualsAndHashCode;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Uniform Resource Name (URN) as in
@@ -56,15 +55,16 @@ import java.util.TreeMap;
  * It will become compliant in one of our future versions. Once it becomes
  * fully compliant this notice will be removed.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
+ * author Yegor Bugayenko (yegor256@gmail.com)
+ * version $Id$
  * @since 0.6
  * @see <a href="http://tools.ietf.org/html/rfc2141">RFC 2141</a>
  */
 @Immutable
 @EqualsAndHashCode
 @SuppressWarnings({
-    "PMD.TooManyMethods", "PMD.UseConcurrentHashMap", "PMD.GodClass"
+    "PMD.TooManyMethods", "PMD.UseConcurrentHashMap",
+    "PMD.GodClass", "PMD.OnlyOneConstructorShouldDoInitialization"
 })
 public final class URN implements Comparable<URN>, Serializable {
 
@@ -118,6 +118,7 @@ public final class URN implements Comparable<URN>, Serializable {
      * @param text The text of the URN
      * @throws URISyntaxException If syntax is not correct
      */
+    @SuppressWarnings("PMD.ConstructorOnlyInitializesOrCallOtherConstructors")
     public URN(final String text) throws URISyntaxException {
         if (text == null) {
             throw new IllegalArgumentException("text can't be NULL");
@@ -134,8 +135,9 @@ public final class URN implements Comparable<URN>, Serializable {
      * @param nid The namespace ID
      * @param nss The namespace specific string
      */
+    @SuppressWarnings("PMD.ConstructorOnlyInitializesOrCallOtherConstructors")
     public URN(final String nid, final String nss) {
-        validateNID(nid);
+        validateNid(nid);
         if (nss == null) {
             throw new IllegalArgumentException("NSS can't be NULL");
         }
@@ -159,6 +161,7 @@ public final class URN implements Comparable<URN>, Serializable {
      * @param text The text of the URN
      * @return The URN created
      */
+    @SuppressWarnings("PMD.ProhibitPublicStaticMethods")
     public static URN create(final String text) {
         if (text == null) {
             throw new IllegalArgumentException("URN can't be NULL");
@@ -185,6 +188,7 @@ public final class URN implements Comparable<URN>, Serializable {
      * @param text The text to validate
      * @return Yes of no
      */
+    @SuppressWarnings("PMD.ProhibitPublicStaticMethods")
     public static boolean isValid(final String text) {
         boolean valid = true;
         try {
@@ -353,21 +357,28 @@ public final class URN implements Comparable<URN>, Serializable {
             );
         }
         final String nid = this.nid();
-        validateNID(nid);
+        validateNid(nid);
     }
 
-    private static void validateNID(final String nid) throws IllegalArgumentException {
+    /**
+     * Validate the nid part of the URN.
+     * It cannot be empty and can hold 1-31 lowercase characters and dashes.
+     * The first character must be a letter.
+     * @param nid The nid part of the urn.
+     * @throws IllegalArgumentException If an invalid nid was supplied
+     */
+    private static void validateNid(final String nid) throws IllegalArgumentException {
         if (nid == null) {
             throw new IllegalArgumentException("NID can't be NULL");
         }
         if (!nid.matches("^[a-z][a-z-]{0,30}$")) {
             throw new IllegalArgumentException(
-                    String.format("NID '%s' can contain up to 31 low case letters or a dash (not the first character)", nid)
+            String.format("NID '%s' can contain up to 31 low case letters or dashes.", nid)
             );
         }
         if (StringUtils.equalsIgnoreCase(URN.PREFIX, nid)) {
             throw new IllegalArgumentException(
-                    "NID can't be 'urn' according to RFC 2141, section 2.1"
+                "NID can't be 'urn' according to RFC 2141, section 2.1"
             );
         }
     }
@@ -378,7 +389,7 @@ public final class URN implements Comparable<URN>, Serializable {
      * @return The map of values
      */
     private static Map<String, String> demap(final String urn) {
-        final Map<String, String> map = new TreeMap<String, String>();
+        final Map<String, String> map = new TreeMap<>();
         final String[] sectors = StringUtils.split(urn, '?');
         if (sectors.length == 2) {
             final String[] parts = StringUtils.split(sectors[1], '&');

--- a/src/main/java/com/jcabi/urn/URN.java
+++ b/src/main/java/com/jcabi/urn/URN.java
@@ -356,7 +356,7 @@ public final class URN implements Comparable<URN>, Serializable {
         validateNID(nid);
     }
 
-    private static void validateNID(String nid) throws IllegalArgumentException {
+    private static void validateNID(final String nid) throws IllegalArgumentException {
         if (nid == null) {
             throw new IllegalArgumentException("NID can't be NULL");
         }
@@ -457,7 +457,7 @@ public final class URN implements Comparable<URN>, Serializable {
         return chr >= 'A' && chr <= 'Z'
             || chr >= '0' && chr <= '9'
             || chr >= 'a' && chr <= 'z'
-            || (chr == '/') || chr == '-';
+            || chr == '/' || chr == '-';
     }
 
 }

--- a/src/main/java/com/jcabi/urn/URN.java
+++ b/src/main/java/com/jcabi/urn/URN.java
@@ -31,9 +31,6 @@ package com.jcabi.urn;
 
 import com.jcabi.aspects.Immutable;
 import com.jcabi.aspects.Tv;
-import lombok.EqualsAndHashCode;
-import org.apache.commons.lang3.StringUtils;
-
 import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
@@ -41,6 +38,8 @@ import java.net.URISyntaxException;
 import java.net.URLDecoder;
 import java.util.Map;
 import java.util.TreeMap;
+import lombok.EqualsAndHashCode;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Uniform Resource Name (URN) as in

--- a/src/main/java/com/jcabi/urn/URN.java
+++ b/src/main/java/com/jcabi/urn/URN.java
@@ -31,6 +31,9 @@ package com.jcabi.urn;
 
 import com.jcabi.aspects.Immutable;
 import com.jcabi.aspects.Tv;
+import lombok.EqualsAndHashCode;
+import org.apache.commons.lang3.StringUtils;
+
 import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
@@ -38,8 +41,6 @@ import java.net.URISyntaxException;
 import java.net.URLDecoder;
 import java.util.Map;
 import java.util.TreeMap;
-import lombok.EqualsAndHashCode;
-import org.apache.commons.lang3.StringUtils;
 
 /**
  * Uniform Resource Name (URN) as in
@@ -98,7 +99,7 @@ public final class URN implements Comparable<URN>, Serializable {
      */
     private static final String REGEX =
         // @checkstyle LineLength (1 line)
-        "^(?i)^urn(?-i):[a-z][a-z-]{0,30}(:([\\-a-zA-Z0-9/]|%[0-9a-fA-F]{2})*)+(\\?\\w+(=([\\-a-zA-Z0-9/]|%[0-9a-fA-F]{2})*)?(&\\w+(=([\\-a-zA-Z0-9/]|%[0-9a-fA-F]{2})*)?)*)?\\*?$";
+        "^(?i)^urn(?-i):[a-z0-9][a-z0-9-]{0,31}(:([\\-a-zA-Z0-9/]|%[0-9a-fA-F]{2})*)+(\\?\\w+(=([\\-a-zA-Z0-9/]|%[0-9a-fA-F]{2})*)?(&\\w+(=([\\-a-zA-Z0-9/]|%[0-9a-fA-F]{2})*)?)*)?\\*?$";
 
     /**
      * The URI.
@@ -371,9 +372,9 @@ public final class URN implements Comparable<URN>, Serializable {
         if (nid == null) {
             throw new IllegalArgumentException("NID can't be NULL");
         }
-        if (!nid.matches("^[a-z][a-z-]{0,30}$")) {
+        if (!nid.matches("^[a-z0-9][a-z0-9-]{0,31}$")) {
             throw new IllegalArgumentException(
-            String.format("NID '%s' can contain up to 31 low case letters or dashes.", nid)
+            String.format("NID '%s' can contain up to 31 low case letters, numbers or dashes.", nid)
             );
         }
         if (StringUtils.equalsIgnoreCase(URN.PREFIX, nid)) {

--- a/src/main/java/com/jcabi/urn/URN.java
+++ b/src/main/java/com/jcabi/urn/URN.java
@@ -31,6 +31,9 @@ package com.jcabi.urn;
 
 import com.jcabi.aspects.Immutable;
 import com.jcabi.aspects.Tv;
+import lombok.EqualsAndHashCode;
+import org.apache.commons.lang3.StringUtils;
+
 import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
@@ -38,8 +41,6 @@ import java.net.URISyntaxException;
 import java.net.URLDecoder;
 import java.util.Map;
 import java.util.TreeMap;
-import lombok.EqualsAndHashCode;
-import org.apache.commons.lang3.StringUtils;
 
 /**
  * Uniform Resource Name (URN) as in
@@ -97,7 +98,7 @@ public final class URN implements Comparable<URN>, Serializable {
      */
     private static final String REGEX =
         // @checkstyle LineLength (1 line)
-        "^(?i)^urn(?-i):[a-z]{1,31}(:([\\-a-zA-Z0-9/]|%[0-9a-fA-F]{2})*)+(\\?\\w+(=([\\-a-zA-Z0-9/]|%[0-9a-fA-F]{2})*)?(&\\w+(=([\\-a-zA-Z0-9/]|%[0-9a-fA-F]{2})*)?)*)?\\*?$";
+        "^(?i)^urn(?-i):[a-z][a-z-]{0,30}(:([\\-a-zA-Z0-9/]|%[0-9a-fA-F]{2})*)+(\\?\\w+(=([\\-a-zA-Z0-9/]|%[0-9a-fA-F]{2})*)?(&\\w+(=([\\-a-zA-Z0-9/]|%[0-9a-fA-F]{2})*)?)*)?\\*?$";
 
     /**
      * The URI.
@@ -134,9 +135,7 @@ public final class URN implements Comparable<URN>, Serializable {
      * @param nss The namespace specific string
      */
     public URN(final String nid, final String nss) {
-        if (nid == null) {
-            throw new IllegalArgumentException("NID can't be NULL");
-        }
+        validateNID(nid);
         if (nss == null) {
             throw new IllegalArgumentException("NSS can't be NULL");
         }
@@ -354,17 +353,21 @@ public final class URN implements Comparable<URN>, Serializable {
             );
         }
         final String nid = this.nid();
-        if (!nid.matches("^[a-z]{1,31}$")) {
+        validateNID(nid);
+    }
+
+    private static void validateNID(String nid) throws IllegalArgumentException {
+        if (nid == null) {
+            throw new IllegalArgumentException("NID can't be NULL");
+        }
+        if (!nid.matches("^[a-z][a-z-]{0,30}$")) {
             throw new IllegalArgumentException(
-                String.format(
-                    "NID '%s' can contain up to 31 low case letters",
-                    this.nid()
-                )
+                    String.format("NID '%s' can contain up to 31 low case letters or a dash (not the first character)", nid)
             );
         }
         if (StringUtils.equalsIgnoreCase(URN.PREFIX, nid)) {
             throw new IllegalArgumentException(
-                "NID can't be 'urn' according to RFC 2141, section 2.1"
+                    "NID can't be 'urn' according to RFC 2141, section 2.1"
             );
         }
     }

--- a/src/main/java/com/jcabi/urn/package-info.java
+++ b/src/main/java/com/jcabi/urn/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2012-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/mock/java/com/jcabi/urn/UrnMocker.java
+++ b/src/mock/java/com/jcabi/urn/UrnMocker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2012-2017, jcabi.com
  * All rights reserved.
  *
@@ -33,11 +33,11 @@ import java.util.UUID;
 
 /**
  * Mocker of {@link URN}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
+ * author Yegor Bugayenko (yegor256@gmail.com)
+ * version $Id$
  * @since 0.6
  */
-public final class URNMocker {
+public final class UrnMocker {
 
     /**
      * Namespace ID.
@@ -52,7 +52,7 @@ public final class URNMocker {
     /**
      * Public ctor.
      */
-    public URNMocker() {
+    public UrnMocker() {
         this.nid = "test";
         this.nss = UUID.randomUUID().toString();
     }
@@ -62,7 +62,7 @@ public final class URNMocker {
      * @param name The namespace
      * @return This object
      */
-    public URNMocker withNid(final String name) {
+    public UrnMocker withNid(final String name) {
         this.nid = name;
         return this;
     }
@@ -72,7 +72,7 @@ public final class URNMocker {
      * @param text The nss
      * @return This object
      */
-    public URNMocker withNss(final String text) {
+    public UrnMocker withNss(final String text) {
         this.nss = text;
         return this;
     }

--- a/src/mock/java/com/jcabi/urn/package-info.java
+++ b/src/mock/java/com/jcabi/urn/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2012-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/test/java/com/jcabi/urn/URNTest.java
+++ b/src/test/java/com/jcabi/urn/URNTest.java
@@ -29,16 +29,18 @@
  */
 package com.jcabi.urn;
 
+import org.apache.commons.lang3.SerializationUtils;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import org.apache.commons.lang3.SerializationUtils;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
-import org.junit.Ignore;
-import org.junit.Test;
 
 /**
  * Uniform Resource Name (URN), tests.
@@ -56,8 +58,8 @@ public final class URNTest {
      */
     @Test
     public void instantiatesFromText() throws Exception {
-        final URN urn = new URN("urn:jcabi:jeff%20lebowski%2540");
-        MatcherAssert.assertThat(urn.nid(), Matchers.equalTo("jcabi"));
+        final URN urn = new URN("urn:jcabi-nid:jeff%20lebowski%2540");
+        MatcherAssert.assertThat(urn.nid(), Matchers.equalTo("jcabi-nid"));
         MatcherAssert.assertThat(
             urn.nss(),
             Matchers.equalTo("jeff lebowski%40")
@@ -70,20 +72,20 @@ public final class URNTest {
      */
     @Test
     public void encodesNssAsRequiredByUrlSyntax() throws Exception {
-        final URN urn = new URN("test", "walter sobchak!");
+        final URN urn = new URN("test-nid", "walter sobchak!");
         MatcherAssert.assertThat(
             urn.toString(),
-            Matchers.equalTo("urn:test:walter%20sobchak%21")
+            Matchers.equalTo("urn:test-nid:walter%20sobchak%21")
         );
     }
 
     /**
      * URN can throw exception when text is NULL.
-     * @throws Exception If there is some problem inside
      */
-    @Test(expected = IllegalArgumentException.class)
-    public void throwsExceptionWhenTextIsNull() throws Exception {
-        new URN(null);
+    @Test
+    public void throwsExceptionWhenTextIsNull() {
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> new URN(null));
     }
 
     /**
@@ -102,20 +104,38 @@ public final class URNTest {
 
     /**
      * URN can throw exception when NID is NULL.
-     * @throws Exception If there is some problem inside
      */
-    @Test(expected = IllegalArgumentException.class)
-    public void throwsExceptionWhenNidIsNull() throws Exception {
-        new URN(null, "some-test-nss");
+    @Test
+    public void throwsExceptionWhenNidIsNull() {
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> new URN(null, "some-test-nss"));
+    }
+
+    /**
+     * URN can throw exception when NID is invalid (dash not allowed as first character).
+     */
+    @Test
+    public void throwsExceptionWhenNidStartsWithDash() {
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> new URN("-invalid", "some-test-nss"));
+    }
+
+    /**
+     * URN can throw exception when NID is invalid (colon not allowed).
+     */
+    @Test
+    public void throwsExceptionWhenNidIsInvalid() {
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> new URN("invalid:nid", "some-test-nss"));
     }
 
     /**
      * URN can throw exception when NSS is NULL.
-     * @throws Exception If there is some problem inside
      */
-    @Test(expected = IllegalArgumentException.class)
-    public void throwsExceptionWhenNssIsNull() throws Exception {
-        new URN("namespace1", null);
+    @Test
+    public void throwsExceptionWhenNssIsNull() {
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> new URN("namespace1", null));
     }
 
     /**
@@ -166,11 +186,11 @@ public final class URNTest {
 
     /**
      * URN can catch incorrect syntax.
-     * @throws Exception If there is some problem inside
      */
-    @Test(expected = URISyntaxException.class)
-    public void catchesIncorrectURNSyntax() throws Exception {
-        new URN("some incorrect name");
+    @Test
+    public void catchesIncorrectURNSyntax() {
+        Assertions.assertThrows(URISyntaxException.class,
+                () -> new URN("some incorrect name"));
     }
 
     /**
@@ -248,20 +268,20 @@ public final class URNTest {
 
     /**
      * URN can be "empty" only in one form.
-     * @throws Exception If there is some problem inside
      */
-    @Test(expected = IllegalArgumentException.class)
-    public void emptyURNHasOnlyOneVariant() throws Exception {
-        new URN("void", "it-is-impossible-to-have-any-NSS-here");
+    @Test
+    public void emptyURNHasOnlyOneVariant() {
+       Assertions.assertThrows(IllegalArgumentException.class,
+                () -> new URN("void", "it-is-impossible-to-have-any-NSS-here"));
     }
 
     /**
      * URN can be "empty" only in one form, with from-text ctor.
-     * @throws Exception If there is some problem inside
      */
-    @Test(expected = URISyntaxException.class)
-    public void emptyURNHasOnlyOneVariantWithTextCtor() throws Exception {
-        new URN("urn:void:it-is-impossible-to-have-any-NSS-here");
+    @Test
+    public void emptyURNHasOnlyOneVariantWithTextCtor() {
+        Assertions.assertThrows(URISyntaxException.class,
+                () -> new URN("urn:void:it-is-impossible-to-have-any-NSS-here"));
     }
 
     /**
@@ -361,7 +381,7 @@ public final class URNTest {
      * @see https://github.com/jcabi/jcabi-urn/issues/8
      */
     @Test
-    @Ignore
+    @Disabled
     public void checkLexicalEquivalence() throws Exception {
         final String[] urns = {
             "URN:foo:a123,456",

--- a/src/test/java/com/jcabi/urn/UrnTest.java
+++ b/src/test/java/com/jcabi/urn/UrnTest.java
@@ -1,3 +1,4 @@
+package com.jcabi.urn;
 /**
  * Copyright (c) 2012-2017, jcabi.com
  * All rights reserved.
@@ -27,7 +28,6 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package com.jcabi.urn;
 
 import org.apache.commons.lang3.SerializationUtils;
 import org.hamcrest.MatcherAssert;
@@ -35,7 +35,6 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;
@@ -50,7 +49,12 @@ import java.util.List;
  * @since 0.6
  */
 @SuppressWarnings("PMD.TooManyMethods")
-public final class URNTest {
+public final class UrnTest {
+
+    /**
+     * Test NSS variable used in various test cases.
+     */
+    private static final String TEST_NSS = "some-test-nss";
 
     /**
      * URN can be instantiated from plain text.
@@ -85,7 +89,7 @@ public final class URNTest {
     @Test
     public void throwsExceptionWhenTextIsNull() {
         Assertions.assertThrows(IllegalArgumentException.class,
-                () -> new URN(null));
+            () -> new URN(null));
     }
 
     /**
@@ -108,7 +112,7 @@ public final class URNTest {
     @Test
     public void throwsExceptionWhenNidIsNull() {
         Assertions.assertThrows(IllegalArgumentException.class,
-                () -> new URN(null, "some-test-nss"));
+            () -> new URN(null, UrnTest.TEST_NSS));
     }
 
     /**
@@ -117,7 +121,7 @@ public final class URNTest {
     @Test
     public void throwsExceptionWhenNidStartsWithDash() {
         Assertions.assertThrows(IllegalArgumentException.class,
-                () -> new URN("-invalid", "some-test-nss"));
+            () -> new URN("-invalid", UrnTest.TEST_NSS));
     }
 
     /**
@@ -126,7 +130,7 @@ public final class URNTest {
     @Test
     public void throwsExceptionWhenNidIsInvalid() {
         Assertions.assertThrows(IllegalArgumentException.class,
-                () -> new URN("invalid:nid", "some-test-nss"));
+            () -> new URN("invalid:nid", UrnTest.TEST_NSS));
     }
 
     /**
@@ -135,7 +139,7 @@ public final class URNTest {
     @Test
     public void throwsExceptionWhenNssIsNull() {
         Assertions.assertThrows(IllegalArgumentException.class,
-                () -> new URN("namespace1", null));
+            () -> new URN("namespace1", null));
     }
 
     /**
@@ -190,7 +194,7 @@ public final class URNTest {
     @Test
     public void catchesIncorrectURNSyntax() {
         Assertions.assertThrows(URISyntaxException.class,
-                () -> new URN("some incorrect name"));
+            () -> new URN("some incorrect name"));
     }
 
     /**
@@ -214,6 +218,8 @@ public final class URNTest {
             "urn:verylongnamespaceid:",
             "urn:a:?alpha=50*",
             "urn:a:b/c/d",
+            "urn:multiple:colon:urn:1234",
+            "urn:with-dash-nid:1234",
         };
         for (final String text : texts) {
             final URN urn = URN.create(text);

--- a/src/test/java/com/jcabi/urn/UrnTest.java
+++ b/src/test/java/com/jcabi/urn/UrnTest.java
@@ -29,17 +29,17 @@
  */
 package com.jcabi.urn;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import org.apache.commons.lang3.SerializationUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 
 /**
  * Uniform Resource Name (URN), tests.
@@ -225,7 +225,7 @@ public final class UrnTest {
             "urn:multiple:colon:urn:1234",
             "urn:with-dash-nid:1234",
             "urn:let-num-123:12345",
-            "urn:exactly-32-characters-1234567890:12345"
+            "urn:exactly-32-characters-1234567890:12345",
         };
         for (final String text : texts) {
             final URN urn = URN.create(text);

--- a/src/test/java/com/jcabi/urn/UrnTest.java
+++ b/src/test/java/com/jcabi/urn/UrnTest.java
@@ -1,5 +1,4 @@
-package com.jcabi.urn;
-/**
+/*
  * Copyright (c) 2012-2017, jcabi.com
  * All rights reserved.
  *
@@ -28,6 +27,7 @@ package com.jcabi.urn;
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+package com.jcabi.urn;
 
 import org.apache.commons.lang3.SerializationUtils;
 import org.hamcrest.MatcherAssert;
@@ -44,8 +44,8 @@ import java.util.List;
 /**
  * Uniform Resource Name (URN), tests.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
+ * author Yegor Bugayenko (yegor256@gmail.com)
+ * version $Id$
  * @since 0.6
  */
 @SuppressWarnings("PMD.TooManyMethods")
@@ -88,8 +88,7 @@ public final class UrnTest {
      */
     @Test
     public void throwsExceptionWhenTextIsNull() {
-        Assertions.assertThrows(IllegalArgumentException.class,
-            () -> new URN(null));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new URN(null));
     }
 
     /**
@@ -111,8 +110,9 @@ public final class UrnTest {
      */
     @Test
     public void throwsExceptionWhenNidIsNull() {
-        Assertions.assertThrows(IllegalArgumentException.class,
-            () -> new URN(null, UrnTest.TEST_NSS));
+        Assertions.assertThrows(
+            IllegalArgumentException.class, () -> new URN(null, UrnTest.TEST_NSS)
+        );
     }
 
     /**
@@ -120,8 +120,9 @@ public final class UrnTest {
      */
     @Test
     public void throwsExceptionWhenNidStartsWithDash() {
-        Assertions.assertThrows(IllegalArgumentException.class,
-            () -> new URN("-invalid", UrnTest.TEST_NSS));
+        Assertions.assertThrows(
+            IllegalArgumentException.class, () -> new URN("-invalid", UrnTest.TEST_NSS)
+        );
     }
 
     /**
@@ -129,8 +130,9 @@ public final class UrnTest {
      */
     @Test
     public void throwsExceptionWhenNidIsInvalid() {
-        Assertions.assertThrows(IllegalArgumentException.class,
-            () -> new URN("invalid:nid", UrnTest.TEST_NSS));
+        Assertions.assertThrows(
+            IllegalArgumentException.class, () -> new URN("invalid:nid", UrnTest.TEST_NSS)
+        );
     }
 
     /**
@@ -138,8 +140,9 @@ public final class UrnTest {
      */
     @Test
     public void throwsExceptionWhenNssIsNull() {
-        Assertions.assertThrows(IllegalArgumentException.class,
-            () -> new URN("namespace1", null));
+        Assertions.assertThrows(
+            IllegalArgumentException.class, () -> new URN("namespace1", null)
+        );
     }
 
     /**
@@ -192,9 +195,10 @@ public final class UrnTest {
      * URN can catch incorrect syntax.
      */
     @Test
-    public void catchesIncorrectURNSyntax() {
-        Assertions.assertThrows(URISyntaxException.class,
-            () -> new URN("some incorrect name"));
+    public void catchesIncorrectUrnSyntax() {
+        Assertions.assertThrows(
+            URISyntaxException.class, () -> new URN("some incorrect name")
+        );
     }
 
     /**
@@ -202,7 +206,7 @@ public final class UrnTest {
      * @throws Exception If there is some problem inside
      */
     @Test
-    public void passesCorrectURNSyntax() throws Exception {
+    public void passesCorrectUrnSyntax() throws Exception {
         final String[] texts = {
             "URN:hello:test",
             "urn:foo:some%20text%20with%20spaces",
@@ -236,7 +240,7 @@ public final class UrnTest {
      * @throws Exception If there is some problem inside
      */
     @Test
-    public void throwsExceptionForIncorrectURNSyntax() throws Exception {
+    public void throwsExceptionForIncorrectUrnSyntax() throws Exception {
         final String[] texts = {
             "abc",
             "",
@@ -267,7 +271,7 @@ public final class UrnTest {
      * @throws Exception If there is some problem inside
      */
     @Test
-    public void emptyURNIsAFirstClassCitizen() throws Exception {
+    public void emptyUrnIsAFirstClassCitizen() throws Exception {
         final URN urn = new URN();
         MatcherAssert.assertThat(urn.isEmpty(), Matchers.equalTo(true));
     }
@@ -276,18 +280,22 @@ public final class UrnTest {
      * URN can be "empty" only in one form.
      */
     @Test
-    public void emptyURNHasOnlyOneVariant() {
-       Assertions.assertThrows(IllegalArgumentException.class,
-                () -> new URN("void", "it-is-impossible-to-have-any-NSS-here"));
+    public void emptyUrnHasOnlyOneVariant() {
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> new URN("void", "it-is-impossible-to-have-any-NSS-here")
+        );
     }
 
     /**
      * URN can be "empty" only in one form, with from-text ctor.
      */
     @Test
-    public void emptyURNHasOnlyOneVariantWithTextCtor() {
-        Assertions.assertThrows(URISyntaxException.class,
-                () -> new URN("urn:void:it-is-impossible-to-have-any-NSS-here"));
+    public void emptyUrnHasOnlyOneVariantWithTextCtor() {
+        Assertions.assertThrows(
+            URISyntaxException.class,
+            () -> new URN("urn:void:it-is-impossible-to-have-any-NSS-here")
+        );
     }
 
     /**
@@ -295,7 +303,7 @@ public final class UrnTest {
      * @throws Exception If there is some problem inside
      */
     @Test
-    public void matchesPatternWithAnotherURN() throws Exception {
+    public void matchesPatternWithAnotherUrn() throws Exception {
         MatcherAssert.assertThat(
             "matches",
             new URN("urn:test:file").matches("urn:test:*")
@@ -375,8 +383,8 @@ public final class UrnTest {
     @Test
     public void mocksUrnWithAMocker() throws Exception {
         MatcherAssert.assertThat(
-            new URNMocker().mock(),
-            Matchers.not(Matchers.equalTo(new URNMocker().mock()))
+            new UrnMocker().mock(),
+            Matchers.not(Matchers.equalTo(new UrnMocker().mock()))
         );
     }
 
@@ -384,7 +392,7 @@ public final class UrnTest {
      * URN can be lexical equivalent according to RFC 2144, section 6.
      * @throws Exception if URN parsing fails.
      * @see <a href="http://www.ietf.org/rfc/rfc2141.txt"/>
-     * @see https://github.com/jcabi/jcabi-urn/issues/8
+     * @see <a href="https://github.com/jcabi/jcabi-urn/issues/8"/>
      */
     @Test
     @Disabled

--- a/src/test/java/com/jcabi/urn/UrnTest.java
+++ b/src/test/java/com/jcabi/urn/UrnTest.java
@@ -224,6 +224,8 @@ public final class UrnTest {
             "urn:a:b/c/d",
             "urn:multiple:colon:urn:1234",
             "urn:with-dash-nid:1234",
+            "urn:let-num-123:12345",
+            "urn:exactly-32-characters-1234567890:12345"
         };
         for (final String text : texts) {
             final URN urn = URN.create(text);

--- a/src/test/java/com/jcabi/urn/package-info.java
+++ b/src/test/java/com/jcabi/urn/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2012-2017, jcabi.com
  * All rights reserved.
  *


### PR DESCRIPTION
According to chapter 2.1 in the RFC-2141, the NID can contain up to 32 characters, numbers and hyphens. With the first character not to be a hyphen: https://www.ietf.org/rfc/rfc2141.txt

I've fixed this in the URN.java class and added tests for them. I tried to fix all qulice warnings, but couldn't comply with the 'AbbreviationAsWordInNameCheck' of the URN class itself as it would break the library's compliancy.

Also some dependencies could be updated in the parents as they haven't been changed in a while.