### PR TITLE
Upgrade dependencies to latest stable versions

### DIFF
--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04, windows-2022, macos-15]
-        java: [11, 17]
+        java: [17, 21]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-<img src="https://www.jcabi.com/logo-square.svg" width="64px" height="64px" />
+# jcabi-urn
+
+![jcabi logo](https://www.jcabi.com/logo-square.svg)
 
 [![EO principles respected here](https://www.elegantobjects.org/badge.svg)](https://www.elegantobjects.org)
 [![DevOps By Rultor.com](https://www.rultor.com/b/jcabi/jcabi-urn)](https://www.rultor.com/p/jcabi/jcabi-urn)
@@ -32,6 +34,6 @@ the `master` branch, if they look correct.
 
 Please run Maven build before submitting a pull request:
 
-```
-$ mvn clean install -Pqulice
+```bash
+mvn clean install -Pqulice
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.13.0</version>
+      <version>3.20.0</version>
     </dependency>
   </dependencies>
   <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
   <parent>
     <groupId>com.jcabi</groupId>
     <artifactId>jcabi</artifactId>
-    <version>1.38.0</version>
+    <version>1.40.1</version>
   </parent>
   <artifactId>jcabi-urn</artifactId>
   <version>1.0-SNAPSHOT</version>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.18.36</version>
+      <version>1.18.46</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/src/main/java/com/jcabi/urn/URN.java
+++ b/src/main/java/com/jcabi/urn/URN.java
@@ -356,7 +356,7 @@ public final class URN implements Comparable<URN>, Serializable {
                 )
             );
         }
-        if (StringUtils.equalsIgnoreCase(URN.PREFIX, nid)) {
+        if (URN.PREFIX.equalsIgnoreCase(nid)) {
             throw new IllegalArgumentException(
                 "NID can't be 'urn' according to RFC 2141, section 2.1"
             );

--- a/src/main/java/com/jcabi/urn/package-info.java
+++ b/src/main/java/com/jcabi/urn/package-info.java
@@ -9,7 +9,7 @@
  * <p>The only dependency you need is (check our latest version available
  * at <a href="http://www.jcabi.com">www.jcabi.com</a>):
  *
- * <pre>&lt;depedency&gt;
+ * <pre>&lt;dependency&gt;
  *   &lt;groupId&gt;com.jcabi&lt;/groupId&gt;
  *   &lt;artifactId&gt;jcabi-urn&lt;/artifactId&gt;
  * &lt;/dependency&gt;</pre>


### PR DESCRIPTION
@yegor256, this PR upgrades runtime dependencies and the `com.jcabi:jcabi` parent POM, upgrades the CI matrix to modern JDKs, and fixes the `README.md` markdown-lint and `typos` violations that were red on master.

`mvn --errors --batch-mode clean install -Pqulice` passes locally on JDK 17 and JDK 21.

## Bumps

- `com.jcabi:jcabi` parent: `1.38.0` → `1.40.1`
- `org.projectlombok:lombok`: `1.18.36` → `1.18.46`
- `org.apache.commons:commons-lang3`: `3.13.0` → `3.20.0`

## Why parent `1.40.1` and not `1.44.0`

`com.jcabi:parent` `0.71.2+` (shipped inside `jcabi` `1.41.0+`) bumps `junit-bom` to 6.x, which requires JDK 17. With the CI matrix moving to `[17, 21]` here, `1.44.0` would be safe — but `1.40.1` keeps `junit-bom` on `5.13.2` and matches the version already used by `jcabi-xml`, `jcabi-ssh`, and `jcabi-http`, so it's the low-risk pick.

## Source changes

- `URN.validate()`: `commons-lang3` 3.20.0 deprecated `StringUtils.equalsIgnoreCase(CharSequence, CharSequence)`. The sole call site passes two `String` values, so it was switched to `String.equalsIgnoreCase` directly — no behavior change.
- `package-info.java` javadoc: fixed the `<depedency>` → `<dependency>` typo (the only hit from `crate-ci/typos` on master).
- `README.md`: added top-level H1, converted the logo `<img>` tag to markdown image syntax, labelled the shell fence as `bash` and dropped the `$` prompt. Clears all 5 `markdownlint` violations that were failing on master.

## CI matrix

- `.github/workflows/mvn.yml`: `java: [11, 17]` → `java: [17, 21]`.

Qulice `0.25.1` transitively loads `checkstyle 12.3.1`, whose MOJO classes are Java 17 bytecode (`class file version 61.0`). Under JDK 11 the plugin can't be loaded (`ComponentLookupException`). Master has been red on the JDK 11 leg since that Qulice bump — see [run 23061668440](https://github.com/jcabi/jcabi-urn/actions/runs/23061668440). Dropping 11 and adding 21 moves the matrix to supported ground.

## `qulice-maven-plugin` left at `0.25.1`

Matches the parent and sibling projects. `0.26.0` activates stricter Checkstyle rules (`ConstructorsCodeFreeCheck`, `ConstructorsOrderCheck`, `QualifyInnerClassCheck`, extra `RegexpMultilineCheck`) that flag 12 pre-existing style issues in `URN.java` / `URNMocker.java` / `URNTest.java` — substantive constructor refactors that belong in a separate PR.

## Commits

1. `Bump jcabi parent from 1.38.0 to 1.40.1`
2. `Bump lombok from 1.18.36 to 1.18.46`
3. `Bump commons-lang3 from 3.13.0 to 3.20.0` (includes the `StringUtils.equalsIgnoreCase` fix)
4. `Fix 'depedency' typo in package-info javadoc`
5. `Fix README.md markdown-lint violations`
6. `Drop JDK 11 from mvn matrix, test on [17, 21]`

Ready for review and merge.
