### PR TITLE
Bump jcabi parent to 1.44.0 and qulice-maven-plugin to 0.26.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
   <parent>
     <groupId>com.jcabi</groupId>
     <artifactId>jcabi</artifactId>
-    <version>1.40.1</version>
+    <version>1.44.0</version>
   </parent>
   <artifactId>jcabi-urn</artifactId>
   <version>1.0-SNAPSHOT</version>
@@ -84,7 +84,7 @@
           <plugin>
             <groupId>com.qulice</groupId>
             <artifactId>qulice-maven-plugin</artifactId>
-            <version>0.25.1</version>
+            <version>0.26.0</version>
             <configuration>
               <excludes>
                 <exclude>duplicatefinder:.*</exclude>

--- a/src/main/java/com/jcabi/urn/URN.java
+++ b/src/main/java/com/jcabi/urn/URN.java
@@ -89,6 +89,7 @@ public final class URN implements Comparable<URN>, Serializable {
      * Public ctor.
      * @param text The text of the URN
      * @throws URISyntaxException If syntax is not correct
+     * @checkstyle ConstructorsCodeFreeCheck (10 lines)
      */
     public URN(final String text) throws URISyntaxException {
         if (text == null) {
@@ -105,6 +106,8 @@ public final class URN implements Comparable<URN>, Serializable {
      * Public ctor.
      * @param nid The namespace ID
      * @param nss The namespace specific string
+     * @checkstyle ConstructorsCodeFreeCheck (20 lines)
+     * @checkstyle ConstructorsOrderCheck (20 lines)
      */
     public URN(final String nid, final String nss) {
         if (nid == null) {
@@ -139,6 +142,7 @@ public final class URN implements Comparable<URN>, Serializable {
             throw new IllegalArgumentException("URN can't be NULL");
         }
         try {
+            // @checkstyle QualifyInnerClassCheck (1 line)
             return new URN(text);
         } catch (final URISyntaxException ex) {
             throw new IllegalArgumentException(ex);
@@ -182,6 +186,7 @@ public final class URN implements Comparable<URN>, Serializable {
     public static boolean isValid(final String text) {
         boolean valid = true;
         try {
+            // @checkstyle QualifyInnerClassCheck (1 line)
             new URN(text);
         } catch (final URISyntaxException ex) {
             valid = false;
@@ -450,5 +455,4 @@ public final class URN implements Comparable<URN>, Serializable {
             || chr >= 'a' && chr <= 'z'
             || chr == '/' || chr == '-';
     }
-
 }

--- a/src/mock/java/com/jcabi/urn/URNMocker.java
+++ b/src/mock/java/com/jcabi/urn/URNMocker.java
@@ -17,20 +17,12 @@ public final class URNMocker {
     /**
      * Namespace ID.
      */
-    private transient String nid;
+    private transient String nid = "test";
 
     /**
      * Nammespace specific string.
      */
-    private transient String nss;
-
-    /**
-     * Public ctor.
-     */
-    public URNMocker() {
-        this.nid = "test";
-        this.nss = UUID.randomUUID().toString();
-    }
+    private transient String nss = UUID.randomUUID().toString();
 
     /**
      * With this namespace.
@@ -59,5 +51,4 @@ public final class URNMocker {
     public URN mock() {
         return new URN(this.nid, this.nss);
     }
-
 }

--- a/src/test/java/com/jcabi/urn/URNTest.java
+++ b/src/test/java/com/jcabi/urn/URNTest.java
@@ -439,5 +439,4 @@ final class URNTest {
             }
         }
     }
-
 }


### PR DESCRIPTION
@yegor256 this PR upgrades the two outdated versions reported by `mvn versions:display-parent-updates` / `display-plugin-updates` and repairs the qulice lint regressions that the new plugin release surfaces.

## What changed

- `com.jcabi:jcabi` parent: **1.40.1 → 1.44.0**
- `com.qulice:qulice-maven-plugin`: **0.25.1 → 0.26.0**

Other direct dependencies (`jcabi-aspects` 0.26.0, `lombok` 1.18.46, `commons-lang3` 3.20.0) were already at their latest stable versions.

## Lint fixes required by qulice 0.26.0

The new qulice release ships stricter Checkstyle rules. Twelve violations surfaced on first rebuild and were addressed:

- **`ConstructorsCodeFreeCheck`** (new in 0.26.0) — fires on every method call inside a constructor body. For `URN.java` I added nearby `@checkstyle` suppressions over the two public constructors (rewriting them would break the public API and push validation logic into awkward factory wrappers). For `URNMocker.java` I moved the `UUID.randomUUID().toString()` call out of the constructor and into the field initializer, which is the idiomatic fix.
- **`ConstructorsOrderCheck`** — with two non-delegating constructors in `URN`, the check flags the second as "primary must be last". Added a nearby suppression; the two ctors are both primary by design and cannot delegate without re-introducing method calls.
- **`QualifyInnerClassCheck`** — appears to mis-fire on `new URN(...)` from inside `URN`'s own static factory methods (the check adds the top-level class name to its `nested` set, so self-instantiation trips the rule). Suppressed the two occurrences in `URN.create` and `URN.isValid`.
- **`RegexpMultilineCheck`** — removed the empty line before the final closing brace in `URN.java`, `URNMocker.java`, and `URNTest.java`.

## Verification

- `mvn clean install -Pqulice` passes locally on JDK 21.
- All 14 CI checks green on this PR: `mvn` matrix (ubuntu-24.04 / macos-15 / windows-2022 × JDK 17 / 21), plus `actionlint`, `markdown-lint`, `typos`, `pdd`, `copyrights`, `reuse`, `xcop`, `yamllint`.
- 28 tests run, 0 failures, 1 skipped (unchanged from master).

Ready for review / merge.
