### PR TITLE
Upgrade jcabi parent to 1.44.0 and refresh dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
   <parent>
     <groupId>com.jcabi</groupId>
     <artifactId>jcabi</artifactId>
-    <version>1.38.0</version>
+    <version>1.44.0</version>
   </parent>
   <artifactId>jcabi-urn</artifactId>
   <version>1.0-SNAPSHOT</version>
@@ -68,12 +68,12 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.18.36</version>
+      <version>1.18.46</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.13.0</version>
+      <version>3.20.0</version>
     </dependency>
   </dependencies>
   <profiles>

--- a/src/main/java/com/jcabi/urn/URN.java
+++ b/src/main/java/com/jcabi/urn/URN.java
@@ -356,7 +356,7 @@ public final class URN implements Comparable<URN>, Serializable {
                 )
             );
         }
-        if (StringUtils.equalsIgnoreCase(URN.PREFIX, nid)) {
+        if (URN.PREFIX.equalsIgnoreCase(nid)) {
             throw new IllegalArgumentException(
                 "NID can't be 'urn' according to RFC 2141, section 2.1"
             );


### PR DESCRIPTION
This PR refreshes the project to the latest stable artifacts the
`jcabi` parent already exposes:

| dependency / parent | from | to |
| --- | --- | --- |
| `com.jcabi:jcabi` (parent POM) | 1.38.0 | 1.44.0 |
| `org.apache.commons:commons-lang3` | 3.13.0 | 3.20.0 |
| `org.projectlombok:lombok` | 1.18.36 | 1.18.46 |

`jcabi-aspects` was already at 0.26.0, the latest release.

### Code change

`commons-lang3` 3.20 deprecates the static
`StringUtils.equalsIgnoreCase(CharSequence, CharSequence)`. The single
call site in `URN#validate` was switched to plain
`String#equalsIgnoreCase`, since `URN.PREFIX` and `nid` are both
`String`. Without this change the new deprecation warning would fail
the build under the `-Werror` compiler flag set by the parent.

### Verification

```
mvn --batch-mode clean install -Pqulice
[INFO] Tests run: 28, Failures: 0, Errors: 0, Skipped: 1
[INFO] BUILD SUCCESS
```

### Notes about `qulice 0.26.0`

I attempted to bump the linter to `0.26.0` (the parent stays on
`0.25.1`) but that release ships two new checks that would each
require an architectural rewrite rather than a code clean-up:

- `ConstructorsCodeFreeCheck` rejects every method call inside a
  constructor (regex `text.matches(...)`, `String.format(...)`,
  `URN.encode(...)` and the private `validate()` helper), which
  forces the validation/normalisation logic out of every public
  `URN(...)` constructor. Since these constructors are part of the
  public API and validation can't be deferred without a behavioural
  change, this is left out of scope.
- `QualifyInnerClassCheck` adds the root class itself to its
  "nested" set, so any `new URN(...)` inside `URN.java` (e.g. the
  static factory `URN.create`) is reported. This looks like a bug in
  the check rather than a code smell to fix here.

The local `qulice-maven-plugin` version override was therefore left at
`0.25.1`, which matches what the upgraded parent provides anyway.

