### PR TITLE
Upgrade qulice-maven-plugin to 0.27.2

### DIFF
--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04, windows-2022, macos-15]
-        java: [17, 21]
+        java: [21]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v4

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
           <plugin>
             <groupId>com.qulice</groupId>
             <artifactId>qulice-maven-plugin</artifactId>
-            <version>0.26.0</version>
+            <version>0.27.2</version>
             <configuration>
               <excludes>
                 <exclude>duplicatefinder:.*</exclude>

--- a/src/mock/java/com/jcabi/urn/URNMocker.java
+++ b/src/mock/java/com/jcabi/urn/URNMocker.java
@@ -8,7 +8,6 @@ import java.util.UUID;
 
 /**
  * Mocker of {@link URN}.
- *
  * @since 0.6
  * @checkstyle AbbreviationAsWordInNameCheck (500 lines)
  */

--- a/src/mock/java/com/jcabi/urn/package-info.java
+++ b/src/mock/java/com/jcabi/urn/package-info.java
@@ -5,7 +5,6 @@
 
 /**
  * URN, mocks.
- *
  * @since 0.6
  */
 package com.jcabi.urn;

--- a/src/test/java/com/jcabi/urn/URNTest.java
+++ b/src/test/java/com/jcabi/urn/URNTest.java
@@ -18,7 +18,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Uniform Resource Name (URN), tests.
- *
  * @since 0.6
  * @checkstyle AbbreviationAsWordInNameCheck (500 lines)
  */

--- a/src/test/java/com/jcabi/urn/package-info.java
+++ b/src/test/java/com/jcabi/urn/package-info.java
@@ -5,7 +5,6 @@
 
 /**
  * URN, tests.
- *
  * @since 0.6
  */
 package com.jcabi.urn;


### PR DESCRIPTION
@yegor256 — this PR upgrades the only outdated build component in this repository, the `qulice-maven-plugin`, from `0.26.0` to `0.27.2` (current latest stable on Maven Central).

## Changes

1. **`pom.xml`** — bumped `qulice-maven-plugin` from `0.26.0` to `0.27.2`.
2. **Source cleanup for the new Checkstyle rule.** Qulice 0.27.x enables `JavadocEmptyLineBeforeTagCheck`, which forbids a blank Javadoc line right before an at-clause (e.g. before `@since`). The new rule reported four violations in test/mock sources; the offending blank lines have been removed:
   - `src/main` was already clean.
   - `src/test/java/com/jcabi/urn/package-info.java`
   - `src/test/java/com/jcabi/urn/URNTest.java`
   - `src/mock/java/com/jcabi/urn/package-info.java`
   - `src/mock/java/com/jcabi/urn/URNMocker.java`
3. **`.github/workflows/mvn.yml`** — dropped Java 17 from the matrix. The qulice 0.27.x plugin descriptor declares `<requiredJavaVersion>21</requiredJavaVersion>`, so `mvn ... -Pqulice` cannot run on Java 17 any more. The matrix now runs on Java 21 across `ubuntu-24.04`, `windows-2022`, and `macos-15`. (qulice `0.26.0` still required Java 17, which was why the previous matrix was `[17, 21]`.)

## Why no other dependency was bumped

All other direct dependencies and the parent POM are already on the latest published stable versions:
- `com.jcabi:jcabi-aspects 0.26.0`
- `org.projectlombok:lombok 1.18.46`
- `org.apache.commons:commons-lang3 3.20.0`
- parent `com.jcabi:jcabi 1.44.0`

Versions like `org.junit.jupiter 6.1.0-RC1`, `commons-codec 1.22.0`, `commons-io 2.22.0`, `jakarta.servlet 6.2.0-M1`, etc. are reported as updates only because they are transitive entries in the `jcabi` parent and only newer pre-release versions exist; per the task constraints these are skipped (stable only).

## Verification

- `mvn clean install -Pqulice` passes locally.
- `mvn clean install -Pjacoco` passes locally.
- All CI jobs are green on this branch: `mvn` matrix (3 OSes × Java 21), `actionlint`, `copyrights`, `markdown-lint`, `pdd`, `reuse`, `typos`, `xcop`, `yamllint`.

Ready for review and merge.