### PR TITLE
Bump qulice-maven-plugin to 0.27.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,12 +84,11 @@
           <plugin>
             <groupId>com.qulice</groupId>
             <artifactId>qulice-maven-plugin</artifactId>
-            <version>0.27.2</version>
+            <version>0.27.4</version>
             <configuration>
               <excludes>
                 <exclude>duplicatefinder:.*</exclude>
               </excludes>
-              <license>file:${basedir}/LICENSE.txt</license>
             </configuration>
           </plugin>
         </plugins>


### PR DESCRIPTION
@yegor256 this PR upgrades the only dependency in `jcabi-urn` that was lagging behind its latest stable version on Maven Central.

## Summary

- Bumps **`com.qulice:qulice-maven-plugin`** from `0.27.2` to `0.27.4` (current latest on Maven Central).
- Drops the now-unused `<license>file:${basedir}/LICENSE.txt</license>` configuration entry from the `qulice` profile, because the `license` parameter was removed from the plugin in 0.27.4 and produced a `Parameter 'license' is unknown for plugin 'qulice-maven-plugin:0.27.4:check'` warning otherwise.

## Why the rest of the dependencies were left untouched

I cross-checked every dependency and plugin declared directly in `pom.xml` against Maven Central:

| Coordinate | Declared | Latest on Central |
| --- | --- | --- |
| `com.jcabi:jcabi` (parent) | 1.44.0 | 1.44.0 |
| `com.jcabi:jcabi-aspects` | 0.26.0 | 0.26.0 |
| `org.projectlombok:lombok` | 1.18.46 | 1.18.46 |
| `org.apache.commons:commons-lang3` | 3.20.0 | 3.20.0 |
| `com.qulice:qulice-maven-plugin` | 0.27.2 | **0.27.4** |

The newer versions surfaced by `versions:display-dependency-updates` (Guava 33.6.0, commons-codec 1.22.0, commons-io 2.22.0, JUnit 6.1.0-RC1, etc.) are all transitively managed by the `com.jcabi:jcabi:1.44.0` parent POM, so they will land here once the parent is re-released. The pinned GitHub Actions in `.github/workflows/*.yml` (`actions/checkout@v6`, `actions/setup-java@v5`, `codecov/codecov-action@v6`, `crate-ci/typos@v1.45.1`, `DavidAnson/markdownlint-cli2-action@v23`, `fsfe/reuse-action@v6`, `yegor256/copyrights-action@0.0.12`, etc.) are likewise already on their latest releases.

## Verification

- `mvn --batch-mode clean install` -> BUILD SUCCESS, 28 tests, 0 failures.
- `mvn --batch-mode clean install -Pqulice` -> BUILD SUCCESS, no qulice violations, no plugin-parameter warnings.
- All 11 CI checks on this PR are green: `mvn` on `ubuntu-24.04`, `windows-2022`, and `macos-15` (Java 21), plus `actionlint`, `markdown-lint`, `yamllint`, `xcop`, `typos`, `pdd`, `reuse`, and `copyrights`.

Ready for merge whenever you are.