### PR TITLE
Bump qulice-maven-plugin to 0.27.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
           <plugin>
             <groupId>com.qulice</groupId>
             <artifactId>qulice-maven-plugin</artifactId>
-            <version>0.27.4</version>
+            <version>0.27.5</version>
             <configuration>
               <excludes>
                 <exclude>duplicatefinder:.*</exclude>


### PR DESCRIPTION
@yegor256, this PR upgrades the only stable dependency that had a newer version available: `qulice-maven-plugin` from `0.27.4` to `0.27.5`.

## Changes

- `pom.xml`: bump `com.qulice:qulice-maven-plugin` `0.27.4` → `0.27.5`

## Why this is the only change

I ran `mvn versions:display-dependency-updates versions:display-plugin-updates versions:display-property-updates -Pqulice` against `master`. The remaining direct dependencies (`com.jcabi:jcabi-aspects:0.26.0`, `org.projectlombok:lombok:1.18.46`, `org.apache.commons:commons-lang3:3.20.0`) are already at their latest stable versions on Maven Central. The parent (`com.jcabi:jcabi:1.44.0`) is also at the latest stable. Newer versions reported for items in dependency management of the parent are pre-releases (`-RC1`, `-M1`, `-alpha1`) and not eligible per the no-unstable rule. Likewise, every GitHub Action used by the workflows is already pinned to its current stable release.

## Verification

Locally on JDK 21 (Temurin) with Maven 3.9.11:

```
mvn --batch-mode clean install -Pqulice
```

Result: `BUILD SUCCESS`, all 28 unit tests pass, Qulice quality check passes with no new violations.

CI on this PR is green on all jobs (mvn × ubuntu-24.04 / windows-2022 / macos-15, plus reuse, yamllint, copyrights, markdown-lint, xcop, actionlint, typos, pdd).

Ready for merge.