### PR TITLE
Modernize charset usage and bump CI actions

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 21
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           key: maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-jdk-${{ matrix.java }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -16,4 +16,4 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
-      - uses: crate-ci/typos@v1.45.1
+      - uses: crate-ci/typos@v1.45.2

--- a/src/main/java/com/jcabi/urn/URN.java
+++ b/src/main/java/com/jcabi/urn/URN.java
@@ -6,10 +6,10 @@ package com.jcabi.urn;
 
 import com.jcabi.aspects.Immutable;
 import java.io.Serializable;
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Objects;
 import java.util.TreeMap;
@@ -45,11 +45,6 @@ public final class URN implements Comparable<URN>, Serializable {
      * Serialization marker.
      */
     private static final long serialVersionUID = 0xBF46AFCD9612A6DFL;
-
-    /**
-     * Encoding to use.
-     */
-    private static final String ENCODING = "UTF-8";
 
     /**
      * NID of an empty URN.
@@ -243,11 +238,7 @@ public final class URN implements Comparable<URN>, Serializable {
      * @return Namespace specific string
      */
     public String nss() {
-        try {
-            return URLDecoder.decode(this.segment(2), URN.ENCODING);
-        } catch (final UnsupportedEncodingException ex) {
-            throw new IllegalStateException(ex);
-        }
+        return URLDecoder.decode(this.segment(2), StandardCharsets.UTF_8);
     }
 
     /**
@@ -382,11 +373,7 @@ public final class URN implements Comparable<URN>, Serializable {
                 final String[] pair = StringUtils.split(part, '=');
                 final String value;
                 if (pair.length == 2) {
-                    try {
-                        value = URLDecoder.decode(pair[1], URN.ENCODING);
-                    } catch (final UnsupportedEncodingException ex) {
-                        throw new IllegalStateException(ex);
-                    }
+                    value = URLDecoder.decode(pair[1], StandardCharsets.UTF_8);
                 } else {
                     value = "";
                 }
@@ -426,12 +413,7 @@ public final class URN implements Comparable<URN>, Serializable {
      * @return The encoded text
      */
     private static String encode(final String text) {
-        final byte[] bytes;
-        try {
-            bytes = text.getBytes(URN.ENCODING);
-        } catch (final UnsupportedEncodingException ex) {
-            throw new IllegalStateException(ex);
-        }
+        final byte[] bytes = text.getBytes(StandardCharsets.UTF_8);
         final StringBuilder encoded = new StringBuilder(100);
         for (final byte chr : bytes) {
             if (URN.allowed(chr)) {


### PR DESCRIPTION
@yegor256 this small clean-up is ready to merge.

## What changed

1. **`URN` class clean-up** — replaced the legacy `"UTF-8"` string and the unreachable `UnsupportedEncodingException` catch blocks with `StandardCharsets.UTF_8`, using the `Charset` overloads of `URLDecoder.decode` and `String.getBytes`. Same behavior, ~20 fewer lines, no more dead error path. (5e56b4f)
2. **`actions/cache@v4` → `v5`** in the `mvn` and `codecov` workflows. v5 moves to the Node.js 24 runtime; GitHub-hosted runners already meet the runner-version requirement. (ab8fb89)
3. **`crate-ci/typos@v1.45.1` → `v1.45.2`** patch bump. (7c1ccfa)

## Why

I checked the Maven dependency and plugin tree — every direct dependency in this child POM (`jcabi-aspects 0.26.0`, `lombok 1.18.46`, `commons-lang3 3.20.0`) and the qulice plugin (`0.27.5`) is already at the latest stable release, and the parent `com.jcabi:jcabi:1.44.0` is current too. So the only meaningful, non-trivial changes left were the workflow action bumps and the small modernisation in `URN`.

## Verification

- `mvn --batch-mode --errors clean install -Pqulice` passes locally on Temurin 21.
- `yamllint .github/workflows/` is clean.
- All 11 CI jobs on this PR are green: `mvn` on ubuntu-24.04 / macos-15 / windows-2022, plus `actionlint`, `yamllint`, `xcop`, `pdd`, `reuse`, `copyrights`, `markdown-lint`, `typos`.

Three small commits, each scoped to a single concern, so they bisect cleanly.