### PR TITLE
Bump qulice-maven-plugin to 0.27.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
           <plugin>
             <groupId>com.qulice</groupId>
             <artifactId>qulice-maven-plugin</artifactId>
-            <version>0.27.5</version>
+            <version>0.27.6</version>
             <configuration>
               <excludes>
                 <exclude>duplicatefinder:.*</exclude>


### PR DESCRIPTION
@yegor256 this PR upgrades the only outdated build component in the project.

## Changes

- **qulice-maven-plugin**: 0.27.5 -> 0.27.6 (latest stable on Maven Central)

## Why this is the only change

I audited every direct dependency and plugin in pom.xml against Maven Central and every GitHub Action against the latest releases. Everything else is already at the latest stable version:

| Component | Current | Latest |
| --- | --- | --- |
| com.jcabi:jcabi (parent) | 1.44.0 | 1.44.0 |
| com.jcabi:jcabi-aspects | 0.26.0 | 0.26.0 |
| org.projectlombok:lombok | 1.18.46 | 1.18.46 |
| org.apache.commons:commons-lang3 | 3.20.0 | 3.20.0 |
| actions/checkout | v6 | v6.0.2 |
| actions/setup-java | v5 | v5.2.0 |
| actions/cache | v5 | v5.0.5 |
| codecov/codecov-action | v6 | v6.0.0 |
| crate-ci/typos | v1.46.0 | v1.46.0 |
| fsfe/reuse-action | v6 | v6.0.0 |
| DavidAnson/markdownlint-cli2-action | v23 | v23.1.0 |
| ibiqlik/action-yamllint | v3 | v3.1.1 |
| yegor256/copyrights-action | 0.0.12 | 0.0.12 |

The dependency-management entries flagged by versions:display-dependency-updates (junit, guava, etc.) are inherited from the jcabi parent and so are out of scope here.

## Verification

- Local build: mvn clean install -> SUCCESS
- Local qulice: mvn clean install -Pqulice -> SUCCESS, no new warnings
- CI on this PR: all 11 jobs green (mvn x3 OS, qulice/checkstyle/pmd/findbugs via mvn, plus actionlint, copyrights, markdown-lint, pdd, reuse, typos, xcop, yamllint)

Ready for merge.
